### PR TITLE
feat(spacing): add pad functions to enable customizable spacing

### DIFF
--- a/sass/themes/_functions.scss
+++ b/sass/themes/_functions.scss
@@ -138,3 +138,40 @@
         calc(var(--is-small, 1) * #{$sm})
     );
 }
+
+/// Used to add spacing.
+/// @access public
+/// @param {Number} $sm - The preferred value when the component's size is small.
+/// @param {Number} $md [$sm] - The preferred value when the component's size is medium.
+/// @param {Number} $lg [$md] - The preferred value when the component's size is large.
+/// @param {Number} $dir [null] - The preferred direction - inline or block.
+/// @return {Function} - The evaluated value.
+@function pad($sm, $md: $sm, $lg: $md, $dir: null) {
+    $spacing: if($dir, --ig-spacing-#{$dir}, --ig-spacing);
+
+    @return max(
+        calc(var(--is-large, 1) * #{$lg} * var(#{$spacing}-large, var(#{$spacing}, --ig-spacing))),
+        calc(var(--is-medium, 1) * #{$md} * var(#{$spacing}-medium, var(#{$spacing}, --ig-spacing))),
+        calc(var(--is-small, 1) * #{$sm} * var(#{$spacing}-small, var(#{$spacing}, --ig-spacing)))
+    );
+}
+
+/// Used to add inline spacing.
+/// @access public
+/// @param {Number} $sm - The preferred value when the component's size is small.
+/// @param {Number} $md [$sm] - The preferred value when the component's size is medium.
+/// @param {Number} $lg [$md] - The preferred value when the component's size is large.
+/// @return {Function} - The evaluated value.
+@function pad-inline($sm, $md: $sm, $lg: $md) {
+    @return pad($sm, $md, $lg, $dir: inline);
+}
+
+/// Used to add block spacing.
+/// @access public
+/// @param {Number} $sm - The preferred value when the component's size is small.
+/// @param {Number} $md [$sm] - The preferred value when the component's size is medium.
+/// @param {Number} $lg [$md] - The preferred value when the component's size is large.
+/// @return {Function} - The evaluated value.
+@function pad-block($sm, $md: $sm, $lg: $md) {
+    @return pad($sm, $md, $lg, $dir: block);
+}

--- a/test/_themes.spec.scss
+++ b/test/_themes.spec.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable max-line-length */
 /* stylelint-disable value-no-vendor-prefix */
 /* stylelint-disable color-function-notation */
 /* stylelint-disable max-nesting-depth */
@@ -277,6 +278,77 @@ $schema: (
                     pointer-events: none;
                     overflow: hidden;
                     appearance: none;
+                }
+            }
+        }
+
+        @include describe('Spacing') {
+            @include it('should use customizable spacing when declaring padding/margin') {
+                @include assert() {
+                    @include output() {
+                        padding: pad(14px);
+                    }
+
+                    @include expect() {
+                        padding:
+                            max(
+                                calc(
+                                    var(--is-large, 1) * 14px * var(--ig-spacing-large, var(--ig-spacing, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-medium, 1) * 14px * var(--ig-spacing-medium, var(--ig-spacing, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-small, 1) * 14px * var(--ig-spacing-small, var(--ig-spacing, --ig-spacing))
+                                )
+                            );
+                    }
+                }
+            }
+
+            @include it('should use customizable inline spacing when declaring inline padding/margin') {
+                @include assert() {
+                    @include output() {
+                        padding-inline: pad-inline(14px);
+                    }
+
+                    @include expect() {
+                        padding-inline:
+                            max(
+                                calc(
+                                    var(--is-large, 1) * 14px * var(--ig-spacing-inline-large, var(--ig-spacing-inline, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-medium, 1) * 14px * var(--ig-spacing-inline-medium, var(--ig-spacing-inline, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-small, 1) * 14px * var(--ig-spacing-inline-small, var(--ig-spacing-inline, --ig-spacing))
+                                )
+                            );
+                    }
+                }
+            }
+
+            @include it('should use customizable block spacing when declaring inline padding/margin') {
+                @include assert() {
+                    @include output() {
+                        padding-block: pad-block(4px, 8px, 16px);
+                    }
+
+                    @include expect() {
+                        padding-block:
+                            max(
+                                calc(
+                                    var(--is-large, 1) * 16px * var(--ig-spacing-block-large, var(--ig-spacing-block, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-medium, 1) * 8px * var(--ig-spacing-block-medium, var(--ig-spacing-block, --ig-spacing))
+                                ),
+                                calc(
+                                    var(--is-small, 1) * 4px * var(--ig-spacing-block-small, var(--ig-spacing-block, --ig-spacing))
+                                )
+                            );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #15 

This PR adds the ability to dynamically customize the spacing a component theme sets internally by allowing the users to set the --ig-spacing CSS variable globally on a per-component basis.

### Example:


#### Pad in both directions:

```scss
.my-class {
   // This will add inline and block padding and allow users to customize it
   // at runtime by changing the value of `--ig-spacing`
   padding: pad(4px, 8px, 16px);
}
```

#### Inline spacing:
```scss
.my-class {
   // This will add inline padding and allow users to customize it
   // at runtime by changing the value of `--ig-spacing` or `--ig-spacing-inline`
   padding-inline: pad-inline(4px, 8px, 16px);
}
```

#### Block spacing:
```scss
.my-class {
   // This will add block padding and allow users to customize it
   // at runtime by changing the value of `--ig-spacing` or `--ig-spacing-block`
   padding-block: pad-block(4px, 8px, 16px);
}
```

### Runtime changes:

Modifying the spacing factor for a specific size only:
```css
.my-class {
  --ig-spacing-small: .5; // Reduces the predefined spacing to 50% of the original values when the component's size is set to small.
  --ig-spacing-inline: .75; // Reduces the predefined inline spacing to 75% of the original values in all sizes.
}
```

Conversely, the modifications above can be applied in many various scenarios by assigning values to different CSS variables - `--ig-spacing-small`, `--ig-spacing-medium`, `--ig-spacing-large`, `--ig-spacing-inline-small`, `--ig-spacing-inline-medium`, `--ig-spacing-inline-large`, `--ig-spacing-block-small`, `--ig-spacing-block-medium`, `--ig-spacing-block-large`, `--ig-spacing-block`, `--ig-spacing-inline`, and simply `--ig-spacing` ;