### PR TITLE
sassdoc(*): add package annotation identifier

### DIFF
--- a/sass/animations/_easings.scss
+++ b/sass/animations/_easings.scss
@@ -1,4 +1,5 @@
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/_mixins.scss
+++ b/sass/animations/_mixins.scss
@@ -3,11 +3,16 @@
 @use 'sass:map';
 @use 'sass:string';
 
+////
+/// @package theming
+/// @group animations
+/// @access public
+/// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>
+////
+
 $keyframes: () !default;
 
 /// Registers a keyframes animation in the keyframes registry.
-/// @access public
-/// @group animations
 /// @param {String} $name - The name of the keyframes animation.
 @mixin keyframes($name) {
     $keyframe: map.has-key($keyframes, $name);
@@ -25,8 +30,6 @@ $keyframes: () !default;
 }
 
 /// Animates an element.
-/// @access public
-/// @group animations
 /// @param {List} $animate - The list of animation properties.
 /// @example scss - Animating an element
 ///  @include fade-in(); // include the 'fade-in' keyframes animation mixin

--- a/sass/animations/entrances/_bounce.scss
+++ b/sass/animations/entrances/_bounce.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_fade.scss
+++ b/sass/animations/entrances/_fade.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_flicker.scss
+++ b/sass/animations/entrances/_flicker.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_flip.scss
+++ b/sass/animations/entrances/_flip.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_puff.scss
+++ b/sass/animations/entrances/_puff.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_roll.scss
+++ b/sass/animations/entrances/_roll.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_rotate.scss
+++ b/sass/animations/entrances/_rotate.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_scale.scss
+++ b/sass/animations/entrances/_scale.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_slide.scss
+++ b/sass/animations/entrances/_slide.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_slit.scss
+++ b/sass/animations/entrances/_slit.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_swing.scss
+++ b/sass/animations/entrances/_swing.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/entrances/_swirl.scss
+++ b/sass/animations/entrances/_swirl.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_bounce.scss
+++ b/sass/animations/exits/_bounce.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_fade.scss
+++ b/sass/animations/exits/_fade.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_flicker.scss
+++ b/sass/animations/exits/_flicker.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_flip.scss
+++ b/sass/animations/exits/_flip.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_puff.scss
+++ b/sass/animations/exits/_puff.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_roll.scss
+++ b/sass/animations/exits/_roll.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_rotate.scss
+++ b/sass/animations/exits/_rotate.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_scale.scss
+++ b/sass/animations/exits/_scale.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_slide.scss
+++ b/sass/animations/exits/_slide.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_slit.scss
+++ b/sass/animations/exits/_slit.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_swing.scss
+++ b/sass/animations/exits/_swing.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/exits/_swirl.scss
+++ b/sass/animations/exits/_swirl.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_flip.scss
+++ b/sass/animations/generic/_flip.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_rotate.scss
+++ b/sass/animations/generic/_rotate.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_scale.scss
+++ b/sass/animations/generic/_scale.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_shadows.scss
+++ b/sass/animations/generic/_shadows.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_slide.scss
+++ b/sass/animations/generic/_slide.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/animations/generic/_swing.scss
+++ b/sass/animations/generic/_swing.scss
@@ -1,6 +1,7 @@
 @use '../mixins' as *;
 
 ////
+/// @package theming
 /// @group animations
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/bem/_index.scss
+++ b/sass/bem/_index.scss
@@ -8,6 +8,7 @@
 /// @group bem
 /// @author <a href="https://github.com/runningskull" target="_blank">Juan Patten</a>
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>
+/// @package theming
 ////
 
 /// @type String - The Element separator used. Default '__'.

--- a/sass/color/_charts.scss
+++ b/sass/color/_charts.scss
@@ -1,7 +1,11 @@
-/// A list of color values to be used as brushes in charts.
+////
+/// @package theming
 /// @group palettes
-/// @type List
 /// @access public
+////
+
+/// A list of color values to be used as brushes in charts.
+/// @type List
 /// @prop {Color} brush-1 [rgb(157 231 114)]
 /// @prop {Color} brush-2 [rgb(139 91 177)]
 /// @prop {Color} brush-3 [rgb(109 177 255)]
@@ -26,9 +30,7 @@ $brushes-regular: (
 );
 
 /// A list of color values to be used as color-blind brushes in charts.
-/// @group palettes
 /// @type List
-/// @access public
 /// @prop {Color} brush-1 [rgb(86 180 233)]
 /// @prop {Color} brush-2 [rgb(0 158 115)]
 /// @prop {Color} brush-3 [rgb(240 228 68)]

--- a/sass/color/_functions.scss
+++ b/sass/color/_functions.scss
@@ -9,6 +9,10 @@
 @use 'types';
 @use '../utils/math' as *;
 
+////
+/// @package theming
+////
+
 $_enhanced-accessibility: false;
 
 /// Configures the color module.

--- a/sass/color/_mixins.scss
+++ b/sass/color/_mixins.scss
@@ -5,6 +5,10 @@
 @use 'sass:string';
 @use '../utils/meta' as *;
 
+////
+/// @package theming
+////
+
 // Generates CSS variables for a base color
 // @access private
 @mixin _base($color, $shade, $value) {

--- a/sass/color/_types.scss
+++ b/sass/color/_types.scss
@@ -2,6 +2,7 @@
 @use 'sass:list';
 
 ////
+/// @package theming
 /// @group Palettes
 ////
 

--- a/sass/color/presets/dark/_bootstrap.scss
+++ b/sass/color/presets/dark/_bootstrap.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="dark-bootstrap"
  */
 /// Generates the dark bootstrap palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-bootstrap-palette
 /// @prop {Color} primary [#0d6efd] - The primary color
 /// @prop {Color} secondary [#6c757d] - The secondary color

--- a/sass/color/presets/dark/_extra.scss
+++ b/sass/color/presets/dark/_extra.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="dark"
  */
 /// Generates the dark green palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-green-palette
 /// @prop {Color} primary [#09f] - The primary color
 /// @prop {Color} secondary [#72da67] - The secondary color
@@ -28,8 +32,6 @@ $green-palette: palette(
 
 /// Generates the dark purple palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-purple-palette
 /// @prop {Color} primary [#00b4d6] - The primary color
 /// @prop {Color} secondary [#514590] - The secondary color

--- a/sass/color/presets/dark/_fluent.scss
+++ b/sass/color/presets/dark/_fluent.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="dark-fluent"
  */
 /// Generates the dark fluent palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-fluent-palette
 /// @prop {Color} primary [#0078d4] - The primary color
 /// @prop {Color} secondary [#2b88d8] - The secondary color
@@ -29,8 +33,6 @@ $palette: palette(
 
 /// Generates the dark fluent word palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-fluent-word-palette
 /// @prop {Color} primary [#2b579a] - The primary color
 /// @prop {Color} secondary [#2b579a] - The secondary color
@@ -53,8 +55,6 @@ $word-palette: palette(
 
 /// Generates the dark fluent excel palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-fluent-excel-palette
 /// @prop {Color} primary [#217346] - The primary color
 /// @prop {Color} secondary [#217346] - The secondary color

--- a/sass/color/presets/dark/_indigo.scss
+++ b/sass/color/presets/dark/_indigo.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="dark-indigo"
  */
 /// Generates the dark indigo palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-indigo-palette
 /// @prop {Color} primary [#3f51b5] - The primary color
 /// @prop {Color} secondary [#3f51b5] - The secondary color

--- a/sass/color/presets/dark/_material.scss
+++ b/sass/color/presets/dark/_material.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="dark-material"
  */
 /// Generates the dark material palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name dark-material-palette
 /// @prop {Color} primary [#09f] - The primary color
 /// @prop {Color} secondary [#e41c77] - The secondary color

--- a/sass/color/presets/light/_bootstrap.scss
+++ b/sass/color/presets/light/_bootstrap.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="light-bootstrap"
  */
 /// Generates the light bootstrap palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-bootstrap-palette
 /// @prop {Color} primary [#0d6efd] - The primary color
 /// @prop {Color} secondary [#6c757d] - The secondary color

--- a/sass/color/presets/light/_extra.scss
+++ b/sass/color/presets/light/_extra.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="light"
  */
 /// Generates the light green palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-green-palette
 /// @prop {Color} primary [#09f] - The primary color
 /// @prop {Color} secondary [#72da67] - The secondary color
@@ -28,8 +32,6 @@ $green-palette: palette(
 
 /// Generates the light purple palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-purple-palette
 /// @prop {Color} primary [#00b4d6] - The primary color
 /// @prop {Color} secondary [#514590] - The secondary color

--- a/sass/color/presets/light/_fluent.scss
+++ b/sass/color/presets/light/_fluent.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="light-fluent"
  */
 /// Generates the light fluent palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-fluent-palette
 /// @prop {Color} primary [#0078d4] - The primary color
 /// @prop {Color} secondary [#2b88d8] - The secondary color
@@ -29,8 +33,6 @@ $palette: palette(
 
 /// Generates the light fluent word palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-fluent-word-palette
 /// @prop {Color} primary [#2b579a] - The primary color
 /// @prop {Color} secondary [#2b579a] - The secondary color
@@ -53,8 +55,6 @@ $word-palette: palette(
 
 /// Generates the dark green palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-fluent-excel-palette
 /// @prop {Color} primary [#217346] - The primary color
 /// @prop {Color} secondary [#217346] - The secondary color

--- a/sass/color/presets/light/_indigo.scss
+++ b/sass/color/presets/light/_indigo.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="light-indigo"
  */
 /// Generates the light indigo palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-indigo-palette
 /// @prop {Color} primary [#3f51b5] - The primary color
 /// @prop {Color} secondary [#3f51b5] - The secondary color

--- a/sass/color/presets/light/_material.scss
+++ b/sass/color/presets/light/_material.scss
@@ -1,12 +1,16 @@
 @use '../../functions' as *;
 
+////
+/// @package theming
+/// @group palettes
+/// @access public
+////
+
 /**
  * @sass-export-section="light-material"
  */
 /// Generates the light material palette.
 /// @type Map
-/// @access public
-/// @group palettes
 /// @name light-material-palette
 /// @prop {Color} primary [#09f] - The primary color
 /// @prop {Color} secondary [#e41c77] - The secondary color

--- a/sass/elevations/_functions.scss
+++ b/sass/elevations/_functions.scss
@@ -3,6 +3,7 @@
 @use 'sass:list';
 
 ////
+/// @package theming
 /// @group Elevations
 ////
 

--- a/sass/elevations/_mixins.scss
+++ b/sass/elevations/_mixins.scss
@@ -1,6 +1,7 @@
 @use '../utils/meta' as *;
 
 ////
+/// @package theming
 /// @group Elevations
 ////
 

--- a/sass/elevations/presets/_material.scss
+++ b/sass/elevations/presets/_material.scss
@@ -1,6 +1,7 @@
 @use '../functions' as *;
 
 ////
+/// @package theming
 /// @group elevations
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>
 ////

--- a/sass/themes/_functions.scss
+++ b/sass/themes/_functions.scss
@@ -7,6 +7,10 @@
 @use '../color/functions' as color;
 @use '../utils' as utils;
 
+////
+/// @package theming
+////
+
 /// Digests a theme schema and returns a resolved theme map.
 /// @access private
 /// @param {Map} $schema - A theme schema.

--- a/sass/themes/_mixins.scss
+++ b/sass/themes/_mixins.scss
@@ -5,6 +5,10 @@
 @use '../utils/meta' as *;
 @use '../typography/functions' as *;
 
+////
+/// @package theming
+////
+
 /// A list of ignored keywords to be excluded when generating CSS variables for a theme.
 /// @access private
 $ignored-keys: ('name', 'palette', 'variant', 'selector', 'type', '_meta');

--- a/sass/themes/charts/_category-chart-theme.scss
+++ b/sass/themes/charts/_category-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/charts/_data-chart-theme.scss
+++ b/sass/themes/charts/_data-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/charts/_doughnut-chart-theme.scss
+++ b/sass/themes/charts/_doughnut-chart-theme.scss
@@ -6,6 +6,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/charts/_financial-chart-theme.scss
+++ b/sass/themes/charts/_financial-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access private
 /// @author <a href="https://github.com/didimmova" target="_blank">Dilyana Dimova</a>

--- a/sass/themes/charts/_funnel-chart-theme.scss
+++ b/sass/themes/charts/_funnel-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access private
 /// @author <a href="https://github.com/desig9stein" target="_blank">Marin Popov</a>

--- a/sass/themes/charts/_gauge-theme.scss
+++ b/sass/themes/charts/_gauge-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/charts/_geo-map-theme.scss
+++ b/sass/themes/charts/_geo-map-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access private
 /// @author <a href="https://github.com/didimmova" target="_blank">Dilyana Dimova</a>

--- a/sass/themes/charts/_graph-theme.scss
+++ b/sass/themes/charts/_graph-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/charts/_pie-chart-theme.scss
+++ b/sass/themes/charts/_pie-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/charts/_shape-chart-theme.scss
+++ b/sass/themes/charts/_shape-chart-theme.scss
@@ -7,6 +7,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/charts/_sparkline-theme.scss
+++ b/sass/themes/charts/_sparkline-theme.scss
@@ -6,6 +6,7 @@
 @use '../../typography' as *;
 
 ////
+/// @package theming
 /// @group themes
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_category-chart.scss
+++ b/sass/themes/schemas/charts/dark/_category-chart.scss
@@ -2,6 +2,7 @@
 @use '../light/category-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/schemas/charts/dark/_data-chart.scss
+++ b/sass/themes/schemas/charts/dark/_data-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/data-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_doughnut-chart.scss
+++ b/sass/themes/schemas/charts/dark/_doughnut-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/doughnut-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_financial-chart.scss
+++ b/sass/themes/schemas/charts/dark/_financial-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/financial-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/didimmova" target="_blank">Dilyana Dimova</a>

--- a/sass/themes/schemas/charts/dark/_funnel-chart.scss
+++ b/sass/themes/schemas/charts/dark/_funnel-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/funnel-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/desig9stein" target="_blank">Marin Popov</a>

--- a/sass/themes/schemas/charts/dark/_gauge.scss
+++ b/sass/themes/schemas/charts/dark/_gauge.scss
@@ -1,6 +1,7 @@
 @use '../light/gauge' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/schemas/charts/dark/_geo-map.scss
+++ b/sass/themes/schemas/charts/dark/_geo-map.scss
@@ -1,6 +1,7 @@
 @use '../light/geo-map' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/didimmova" target="_blank">Dilyana Dimova</a>

--- a/sass/themes/schemas/charts/dark/_graph.scss
+++ b/sass/themes/schemas/charts/dark/_graph.scss
@@ -1,6 +1,7 @@
 @use '../light/graph' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_index.scss
+++ b/sass/themes/schemas/charts/dark/_index.scss
@@ -11,6 +11,7 @@
 @use './sparkline' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/desig9stein" target="_blank">Marin Popov</a>

--- a/sass/themes/schemas/charts/dark/_pie-chart.scss
+++ b/sass/themes/schemas/charts/dark/_pie-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/pie-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_shape-chart.scss
+++ b/sass/themes/schemas/charts/dark/_shape-chart.scss
@@ -1,6 +1,7 @@
 @use '../light/shape-chart' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/dark/_sparkline.scss
+++ b/sass/themes/schemas/charts/dark/_sparkline.scss
@@ -1,6 +1,7 @@
 @use '../light/sparkline' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_category-chart.scss
+++ b/sass/themes/schemas/charts/light/_category-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/schemas/charts/light/_data-chart.scss
+++ b/sass/themes/schemas/charts/light/_data-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_doughnut-chart.scss
+++ b/sass/themes/schemas/charts/light/_doughnut-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_financial-chart.scss
+++ b/sass/themes/schemas/charts/light/_financial-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/didimmova" target="_blank">Dilyana Dimova</a>

--- a/sass/themes/schemas/charts/light/_funnel-chart.scss
+++ b/sass/themes/schemas/charts/light/_funnel-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/desig9stein" target="_blank">Marin Popov</a>

--- a/sass/themes/schemas/charts/light/_gauge.scss
+++ b/sass/themes/schemas/charts/light/_gauge.scss
@@ -2,6 +2,7 @@
 @use '../../../../utils/map' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/SisIvanova" target="_blank">Silvia Ivanova</a>

--- a/sass/themes/schemas/charts/light/_geo-map.scss
+++ b/sass/themes/schemas/charts/light/_geo-map.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable max-line-length */
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_graph.scss
+++ b/sass/themes/schemas/charts/light/_graph.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable max-line-length */
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_index.scss
+++ b/sass/themes/schemas/charts/light/_index.scss
@@ -11,6 +11,7 @@
 @use './sparkline' as *;
 
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/desig9stein" target="_blank">Marin Popov</a>

--- a/sass/themes/schemas/charts/light/_pie-chart.scss
+++ b/sass/themes/schemas/charts/light/_pie-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_shape-chart.scss
+++ b/sass/themes/schemas/charts/light/_shape-chart.scss
@@ -1,5 +1,6 @@
 /* stylelint-disable max-line-length */
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/themes/schemas/charts/light/_sparkline.scss
+++ b/sass/themes/schemas/charts/light/_sparkline.scss
@@ -1,4 +1,5 @@
 ////
+/// @package theming
 /// @group schemas
 /// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>

--- a/sass/typography/_functions.scss
+++ b/sass/typography/_functions.scss
@@ -6,6 +6,7 @@
 @use './types';
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/_mixins.scss
+++ b/sass/typography/_mixins.scss
@@ -6,6 +6,7 @@
 @use '../themes/mixins' as *;
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/_types.scss
+++ b/sass/typography/_types.scss
@@ -1,4 +1,5 @@
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/charts/_index.scss
+++ b/sass/typography/charts/_index.scss
@@ -7,8 +7,12 @@
 @use '../../themes/charts/pie-chart-theme' as *;
 @use '../../themes/charts/shape-chart-theme' as *;
 
-/// Includes all chart related typography styles for a given type-scale and target.
+////
+/// @package theming
 /// @group typography
+////
+
+/// Includes all chart related typography styles for a given type-scale and target.
 /// @param {Map} $type-scale - The type-scale to be used when including typography styles.
 /// @param {String} $target ['angular'] - The target platform. Could be 'angular', 'webc', or 'blazor'.
 /// @access public

--- a/sass/typography/presets/_bootstrap.scss
+++ b/sass/typography/presets/_bootstrap.scss
@@ -3,6 +3,7 @@
 @use '../../utils/map' as *;
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/presets/_fluent.scss
+++ b/sass/typography/presets/_fluent.scss
@@ -1,6 +1,7 @@
 @use '../functions' as *;
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/presets/_indigo.scss
+++ b/sass/typography/presets/_indigo.scss
@@ -1,6 +1,7 @@
 @use '../functions' as *;
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/typography/presets/_material.scss
+++ b/sass/typography/presets/_material.scss
@@ -1,6 +1,7 @@
 @use '../functions' as *;
 
 ////
+/// @package theming
 /// @group Typography
 ////
 

--- a/sass/utils/_css.scss
+++ b/sass/utils/_css.scss
@@ -1,6 +1,10 @@
 @use 'sass:list';
 @use 'sass:map';
 
+////
+/// @package theming
+////
+
 /// Expands the provided list of values in all four directions.
 /// Works similar to how to browser expands shorthands for margins.
 /// @access private

--- a/sass/utils/_map.scss
+++ b/sass/utils/_map.scss
@@ -1,6 +1,10 @@
 @use 'sass:map';
 @use 'sass:list';
 
+////
+/// @package theming
+////
+
 /// Removes all null key-value pairs from a map
 /// @access private
 /// @param {Map} $map - The target map to be cleaned.

--- a/sass/utils/_math.scss
+++ b/sass/utils/_math.scss
@@ -1,6 +1,10 @@
 @use 'sass:math';
 @use 'sass:string';
 
+////
+/// @package theming
+////
+
 /// Rounds a number to a certain precision
 /// @group utilities
 /// @access public

--- a/sass/utils/_meta.scss
+++ b/sass/utils/_meta.scss
@@ -1,5 +1,9 @@
 @use 'sass:selector';
 
+////
+/// @package theming
+////
+
 /// Returns true if the scope where it's called is the root of the document.
 /// @access private
 /// @example scss Check if the current scope is root

--- a/sass/utils/_string.scss
+++ b/sass/utils/_string.scss
@@ -3,6 +3,10 @@
 @use 'sass:map';
 @use 'sass:meta';
 
+////
+/// @package theming
+////
+
 /// Splits a string into a list by a given separator.
 /// @access public
 /// @group utilities


### PR DESCRIPTION
Related https://github.com/IgniteUI/igniteui-angular/issues/12691

To validate this PR, you must install [this custom build of the Ignite UI SassDoc Theme](https://github.com/IgniteUI/igniteui-theming/files/10931338/igniteui-sassdoc-theme-0.1.0.tgz).

Steps for validation:

1. Run the following:

```sh
npm install path-to-the-downloaded-sassdoc-theme-from-above/igniteui-sassdoc-theme-0.1.0.tgz
npm run build:docs
npm run serve:docs
```

2. Open [localhost:8080](http://localhost:8080)
3. Verify that clicking on the "Defined in" links points to the correct location in the source code in this repo.

## Blockers
The updated Ignite UI SassDoc Theme should be released and added as a dependency before this PR is merged.
