### PR TITLE
npm(exports): add all sass files as package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     },
     "./functions": {
       "sass": "./sass/_functions.scss"
-    }
+    },
+    "./sass/**/*.*": "./sass/**/*.*"
   },
   "devDependencies": {
     "globby": "^13.1.4",


### PR DESCRIPTION
This PR introduces a change to the exports object in the package.json file to allow for legacy Sass `includePaths` option to work in external packages.