### PR TITLE
refactor(colors): update material preset and contrast colors

### DIFF
--- a/sass/color/_functions.scss
+++ b/sass/color/_functions.scss
@@ -104,7 +104,11 @@ $_enhanced-accessibility: false;
             $result,
             (
                 $variant: map.get($shade, 'raw'),
-                #{$variant}-contrast: text-contrast(map.get($shade, 'raw')),
+                #{$variant}-contrast:
+                    text-contrast(
+                        $background: map.get($shade, 'raw'),
+                        $contrast: 'AA',
+                    ),
                 #{$variant}-hsl: map.get($shade, 'hsl'),
             )
         );

--- a/sass/color/presets/dark/_material.scss
+++ b/sass/color/presets/dark/_material.scss
@@ -22,7 +22,7 @@
 /// @prop {Color} error [#ff134a] - The error color
 $palette: palette(
     $primary: #09f,
-    $secondary: #e41c77,
+    $secondary: #df1b74,
     $surface: #222,
     $info: #1377d5,
     $success: #4eb862,

--- a/sass/color/presets/light/_material.scss
+++ b/sass/color/presets/light/_material.scss
@@ -22,7 +22,7 @@
 /// @prop {Color} error [#ff134a] - The error color
 $palette: palette(
     $primary: #09f,
-    $secondary: #e41c77,
+    $secondary: #df1b74,
     $surface: white,
     $info: #1377d5,
     $success: #4eb862,


### PR DESCRIPTION
Update the material secondary color in the palette presets based on recommendations from the UX team. Also, updates the contrast colors to be generated against AA contrast ration standards instead of AAA.