### PR TITLE
[validator] - refactor dark validator shcema for indigo to include the correct color for the helper text

### DIFF
--- a/sass/themes/schemas/components/dark/_validator.scss
+++ b/sass/themes/schemas/components/dark/_validator.scss
@@ -48,12 +48,20 @@ $dark-bootstrap-validator: extend(
 
 /// Generates a dark indigo validator schema.
 /// @type {Map}
+/// @prop {Map} helper-text-color [contrast-color: ('gray', 50, .8)] - The color used for helper text.
 /// @prop {Map} text-error-color [contrast-color: ('gray', 50, .8)] - The color used for the error message.
 /// @requires $indigo-validator
 /// @requires $dark-validator
 $dark-indigo-validator: extend(
     $indigo-validator,
     (
+        helper-text-color: (
+            contrast-color: (
+                'gray',
+                50,
+                0.8,
+            ),
+        ),
         text-error-color: (
             contrast-color: (
                 'gray',


### PR DESCRIPTION
Closes: #428

The change will affect only web components branch since in angular we don't have a validation component.