### PR TITLE
fix(input-group): use the correct variable for focus background on the input in indigo theme

### DIFF
--- a/sass/themes/schemas/components/dark/_input-group.scss
+++ b/sass/themes/schemas/components/dark/_input-group.scss
@@ -250,6 +250,7 @@ $dark-bootstrap-input-group: extend(
 /// @prop {Map} filled-text-hover-color [contrast-color: ('gray', 50)] - The input text color in the filled state on hover.
 /// @prop {Map} disabled-text-color [contrast-color: ('gray', 50, .2)] - The input text color in the disabled state.
 /// @prop {Map} box-background-hover [contrast-color: ('gray', 50, .1)] - The background color of an input group of type box on hover.
+/// @prop {Map} box-background-focus [contrast-color: ('gray', 50, .1)] - The background color of an input group of type box on focus.
 /// @prop {Map} idle-secondary-color [contrast-color: ('gray', 50, .6)] - The label color in the idle state.
 /// @prop {Map} focused-text-color [contrast-color: ('gray', 50)] - The input text color in the focused state.
 /// @prop {Map} focused-secondary-color [contrast-color: ('gray', 50, .6)] - The label color in the focused state.
@@ -358,6 +359,13 @@ $dark-indigo-input-group: extend(
             ),
         ),
         box-background-hover: (
+            contrast-color: (
+                'gray',
+                50,
+                0.1,
+            ),
+        ),
+        box-background-focus: (
             contrast-color: (
                 'gray',
                 50,

--- a/sass/themes/schemas/components/light/_input-group.scss
+++ b/sass/themes/schemas/components/light/_input-group.scss
@@ -708,6 +708,7 @@ $bootstrap-input-group: extend(
 /// @prop {Color} box-disabled-background [transparent] - The background color of an input group in the disabled state.
 /// @prop {Color} search-disabled-background [transparent] - The background color of an input group of type search in the disabled state.
 /// @prop {Map} box-background-hover [color: ('gray', 900, .05)] - The background color of an input group of type box on hover.
+/// @prop {Map} box-background-focus [color: ('gray', 900, .05)] - The background color of an input group of type box on focus.
 /// @prop {Map} idle-text-color [color: ('gray', 800)] - The input text color in the idle state.
 /// @prop {Map} filled-text-color [color: ('gray', 800)] - The input text color in the filled state.
 /// @prop {Map} disabled-text-color [color: ('gray', 900, .2)] - The input text color in the disabled state.
@@ -805,6 +806,13 @@ $indigo-input-group: extend(
         box-disabled-background: transparent,
         search-disabled-background: transparent,
         box-background-hover: (
+            color: (
+                'gray',
+                900,
+                0.05,
+            ),
+        ),
+        box-background-focus: (
             color: (
                 'gray',
                 900,


### PR DESCRIPTION
closes #422 