### PR TITLE
fix(button): update active-shadow elevation number

### DIFF
--- a/sass/themes/schemas/components/elevation/_button.scss
+++ b/sass/themes/schemas/components/elevation/_button.scss
@@ -20,19 +20,19 @@ $flat-elevation-button: (
 /// @prop {Number} resting-elevation [2] - The elevation level, between 0-24, to be used for the resting state.
 /// @prop {Number} hover-elevation [4] - The elevation level, between 0-24, to be used for the hover state.
 /// @prop {Number} focus-elevation [8] - The elevation level, between 0-24, to be used for the focus state.
-/// @prop {Number} active-elevation [8] - The elevation level, between 0-24, to be used for the focus state.
+/// @prop {Number} active-elevation [4] - The elevation level, between 0-24, to be used for the active state.
 $light-contained-elevation: (
     resting-elevation: 2,
     hover-elevation: 4,
     focus-elevation: 8,
-    active-elevation: 8,
+    active-elevation: 4,
 );
 
 /// @type Map
 /// @prop {Number} resting-elevation [6] - The elevation level, between 0-24, to be used for the resting state.
 /// @prop {Number} hover-elevation [12] - The elevation level, between 0-24, to be used for the hover state.
 /// @prop {Number} focus-elevation [12] - The elevation level, between 0-24, to be used for the focus state.
-/// @prop {Number} active-elevation [12] - The elevation level, between 0-24, to be used for the focus state.
+/// @prop {Number} active-elevation [12] - The elevation level, between 0-24, to be used for the active state.
 $light-fab-elevation: (
     resting-elevation: 6,
     hover-elevation: 12,


### PR DESCRIPTION
Related to [15770](https://github.com/IgniteUI/igniteui-angular/issues/15770)

I saw that in the [Button handoff](https://www.figma.com/design/2dnNPqpR7K7tMrWvf3jHpO/Button?node-id=116-22639&p=f&t=szED0Q9bKlPc0n8P-0) the active state of the Material contained button is supposed to have **elevation-4** applied, but right now it gets **elevation-8**.