### PR TITLE
refactor(combo): change `search-separator-border-color` to `transparent` in all themes

### DIFF
--- a/sass/themes/schemas/components/light/_combo.scss
+++ b/sass/themes/schemas/components/light/_combo.scss
@@ -12,7 +12,7 @@
 /// Generates a light combo schema.
 /// @type {Map}
 /// @prop {Map} empty-list-background [color: 'surface'] - The combo list background color.
-/// @prop {Map} search-separator-border-color [color: ('gray', 500)] - The combo search box separator color.
+/// @prop {Color} search-separator-border-color [transparent] - The combo search box separator color.
 /// @prop {Map} empty-list-placeholder-color [color: ('gray', 700)] - The combo placeholder text color.
 /// @prop {Map} toggle-button-background [color: ('gray', 300)] - The combo toggle button background color.
 /// @prop {Map} toggle-button-background-focus [color: ('gray', 300)] - The combo toggle button background color when the combo is focused.
@@ -50,12 +50,7 @@ $light-combo: (
     empty-list-background: (
         color: 'surface',
     ),
-    search-separator-border-color: (
-        color: (
-            'gray',
-            500,
-        ),
-    ),
+    search-separator-border-color: transparent,
     empty-list-placeholder-color: (
         color: (
             'gray',
@@ -225,7 +220,6 @@ $fluent-combo: extend(
 /// @prop {Map} toggle-button-foreground-filled [color: ('gray', 800)] - The combo toggle button foreground color when the combo is focused.
 /// @prop {Map} toggle-button-foreground-disabled [color: ('gray', 400)] - The combo toggle button foreground color when the combo is disabled.
 /// @prop {Map} empty-list-background [color: ('surface')] - The combo list background color.
-/// @prop {Map} search-separator-border-color [color: ('gray', 400)] - The combo search box separator color.
 /// @prop {Map} empty-list-placeholder-color [color: ('gray', 600)] - The combo placeholder text color.
 /// @prop {Map} clear-button-background [color: ('gray', 300)] - The combo clear button background color.
 /// @prop {Map} clear-button-background-focus [color: ('gray', 300)] - The combo clear button background color when the combo is focused.
@@ -238,12 +232,6 @@ $bootstrap-combo: extend(
         empty-list-background: (
             color: (
                 'surface',
-            ),
-        ),
-        search-separator-border-color: (
-            color: (
-                'gray',
-                400,
             ),
         ),
         empty-list-placeholder-color: (


### PR DESCRIPTION
Closes: https://github.com/IgniteUI/igniteui-theming/issues/421