### PR TITLE
fix(dock-manager): add back prefix to theme map

### DIFF
--- a/sass/themes/components/dock-manager/_dock-manager-theme.scss
+++ b/sass/themes/components/dock-manager/_dock-manager-theme.scss
@@ -74,6 +74,7 @@
         (
             name: $name,
             selector: $selector,
+            prefix: 'igc',
         ),
         meta.keywords($rest)
     );


### PR DESCRIPTION
Related https://github.com/IgniteUI/igniteui-angular/issues/16280#issue-3490537705