### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,8 @@
 name: Npm.js deploy
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/IgniteUI/igniteui-theming/security/code-scanning/2](https://github.com/IgniteUI/igniteui-theming/security/code-scanning/2)

To fix this issue, you should add a `permissions` block to the workflow (`.github/workflows/npm-publish.yml`). This block should specify the minimal permissions required for the workflow. For an NPM publish workflow triggered on release creation, it is usually sufficient to set `contents: read`, unless you need to create new tags or modify repository contents (which you do not in the shown steps).  
You should add the following block at the top level of the YAML file, just after the `name:` or before/after the `on:` block; this will apply the permissions to all jobs in the workflow unless overridden.  
No package changes or additional methods are necessary; the fix is purely in the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
