### PR TITLE
Fix typo in README.md for igniteui-theming args

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -110,7 +110,7 @@ Create or edit `.vscode/mcp.json`:
   "servers": {
     "igniteui-theming": {
       "command": "npx",
-      "args": ["-y", "igniteui-theming", "ignitui-theming-mcp"]
+      "args": ["-y", "igniteui-theming", "igniteui-theming-mcp"]
     }
   }
 }


### PR DESCRIPTION
There was a an "e" missing here