### PR TITLE
fix(dock-manager): use per-component prefix for local CSS variable names

### DIFF
--- a/sass/themes/_mixins.scss
+++ b/sass/themes/_mixins.scss
@@ -88,8 +88,12 @@ $ignored-keys: ('name', 'palette', 'variant', 'selector', 'type', 'theme', 'typo
 /// @param {Map} $theme - The component theme used for generating CSS variables.
 /// @param {String} $name [null] - Deprecated. This parameter is ignored.
 /// @param {Map} $ignored [$ignored-keys] - A list of ignored keywords to be excluded when generating CSS variables.
-/// @example scss Convert theme colors to CSS variables.
-///   $theme: digest-schema((background: color(primary, 500), foreground: contrast-color(color, 500));
+/// @example scss - Convert theme colors to CSS variables.
+///   $theme: digest-schema((
+///     background: color(primary, '500'),
+///     foreground: contrast-color(color, '500')
+///   ));
+///
 ///   :root {
 ///     @include css-vars-from-theme($theme);
 ///   }
@@ -102,14 +106,17 @@ $ignored-keys: ('name', 'palette', 'variant', 'selector', 'type', 'theme', 'typo
 
     $t: map.get($theme, '_meta', 'theme');
     $v: map.get($theme, '_meta', 'variant');
+    $p: map.get($theme, 'prefix');
     $vp: config.variable-prefix();
 
     @each $key, $value in map.remove($theme, $ignored...) {
         @if _is-emittable($key, $value) {
+            $local: if($p, '#{$p}-#{$key}', $key);
+
             @if $vp == 'ig' {
-                --#{$key}: var(--ig-#{$n}-#{$key}, #{$value});
+                --#{$local}: var(--ig-#{$n}-#{$key}, #{$value});
             } @else {
-                --#{$key}: var(--#{$vp}-#{$n}-#{$key}, var(--ig-#{$n}-#{$key}, #{$value}));
+                --#{$local}: var(--#{$vp}-#{$n}-#{$key}, var(--ig-#{$n}-#{$key}, #{$value}));
             }
         }
     }

--- a/sass/themes/schemas/components/dark/_dock-manager.scss
+++ b/sass/themes/schemas/components/dark/_dock-manager.scss
@@ -26,7 +26,7 @@
 /// @prop {Color} tab-background [color: ('gray', 100, .3)] - Sets the background color for tabs.
 /// @prop {Color} tab-background-active [color: ('gray', 100, .3)] - Sets the background color for active tabs.
 /// @prop {Color} tab-border-color-active [color: ('gray', 100)] - Sets the border color for active tabs.
-/// @prop {Color} button-text [contrast-color: 'surface'] - Sets the button text color.
+/// @prop {Color} button-component-text [contrast-color: 'surface'] - Sets the button text color.
 /// @prop {Color} flyout-shadow-color [color: ('gray', 50, .3)] - Sets the flyout shadow color.
 /// @prop {Color} drop-shadow-background [color: ('primary', 900, .3)] - Sets the drop-shadow background color.
 /// @prop {Color} splitter-background [color: ('gray', 100)] - Sets the background color for the splitters.
@@ -140,7 +140,7 @@ $dark-base-dock-manager: (
         ),
     ),
 
-    button-text: (
+    button-component-text: (
         contrast-color: 'surface',
     ),
 
@@ -282,7 +282,7 @@ $dark-bootstrap-dock-manager: extend(
 
 /// Generates a dark indigo dock-manager schema.
 /// @type Map
-/// @prop {Color} button-text [color: ('primary', 200)] - Sets the button text color.
+/// @prop {Color} button-component-text [color: ('primary', 200)] - Sets the button text color.
 /// @prop {Color} joystick-background [color: ('surface')] - Sets the background color of the joystick.
 /// @prop {Color} joystick-background-active [color: ('primary')] - Sets the background color of the joysticks.
 /// @prop {Color} joystick-border-color [color: ('gray', 100)] - Sets the border color of the joystick.
@@ -297,7 +297,7 @@ $dark-indigo-dock-manager: extend(
     $indigo-dock-manager,
     $dark-base-dock-manager,
     (
-        button-text: (
+        button-component-text: (
             color: (
                 'primary',
                 200,

--- a/sass/themes/schemas/components/light/_dock-manager.scss
+++ b/sass/themes/schemas/components/light/_dock-manager.scss
@@ -13,7 +13,7 @@
 /// @prop {Color} active-color [color: 'primary'] - Sets the active text and border colors for tabs, panes, and menus.
 /// @prop {Color} background-color [null] - Sets the base dock manager color as well as the pane headers and tabs background colors.
 /// @prop {Color} border-color [color: ('surface')] - Sets the global border color in the dock manager. Also sets the pane content background and the context menu active background colors.
-/// @prop {Color} button-text [color: ('gray', 800)] - Sets the button text color.
+/// @prop {Color} button-component-text [color: ('gray', 800)] - Sets the button text color.
 /// @prop {Color} context-menu-background-active [color: 'primary'] - Sets the background color for active context menus.
 /// @prop {Color} context-menu-background [null] - Sets the background color for context menus.
 /// @prop {Color} dock-background [null] - Sets the background color of the dock manager.
@@ -60,7 +60,7 @@ $light-dock-manager: (
         ),
     ),
 
-    button-text: (
+    button-component-text: (
         color: (
             'gray',
             800,
@@ -347,7 +347,7 @@ $fluent-dock-manager: extend(
 
 /// Generates a bootstrap dock-manager schema.
 /// @type Map
-/// @prop {Color} button-text [color: 'primary'] - Sets the button text color.
+/// @prop {Color} button-component-text [color: 'primary'] - Sets the button text color.
 /// @prop {Color} context-menu-background [color: 'surface'] - Sets the background color for context menus.
 /// @prop {Color} context-menu-color-active [color: 'surface'] - Sets the text color for active context menus.
 /// @prop {Color} context-menu-color [color: 'primary'] - Sets the text color for context menus.
@@ -364,7 +364,7 @@ $fluent-dock-manager: extend(
 $bootstrap-dock-manager: extend(
     $light-dock-manager,
     (
-        button-text: (
+        button-component-text: (
             color: 'primary',
         ),
 
@@ -446,7 +446,7 @@ $bootstrap-dock-manager: extend(
 /// Generates a light indigo dock-manager schema.
 /// @type Map
 /// @prop {Color} background-color [color: ('gray', 100)] - Sets the base dock manager color as well as the pane headers and tabs background colors.
-/// @prop {Color} button-text [color: 'primary'] - Sets the button text color.
+/// @prop {Color} button-component-text [color: 'primary'] - Sets the button text color.
 /// @prop {Color} context-menu-color-active [contrast-color: 'primary'] - Sets the text color for active context menus.
 /// @prop {Color} context-menu-color [color: ('gray', 700)] - Sets the text color for context menus.
 /// @prop {Color} joystick-background [color: ('primary', 50)] - Sets the background color of the joysticks.
@@ -468,7 +468,7 @@ $indigo-dock-manager: extend(
             ),
         ),
 
-        button-text: (
+        button-component-text: (
             color: 'primary',
         ),
 

--- a/test/_themes.spec.scss
+++ b/test/_themes.spec.scss
@@ -276,6 +276,96 @@ $schema: (
             }
         }
 
+        @include it('should prepend the prefix to CSS variable names when the theme map includes a prefix') {
+            $theme: map.merge(
+                digest-schema($schema),
+                (
+                    prefix: 'igc',
+                )
+            );
+            $name: map.get($theme, '_meta', 'name');
+            $vp: config.variable-prefix();
+
+            @include assert() {
+                @include output() {
+                    @include css-vars-from-theme($theme);
+                }
+
+                @include expect() {
+                    @each $key, $value in map.remove($theme, $ignored-keys...) {
+                        @if $key != 'prefix' {
+                            $fallback: if($vp == 'ig', #{$value}, var(--ig-#{$name}-#{$key}, #{$value}));
+
+                            --igc-#{$key}: var(--#{$vp}-#{$name}-#{$key}, #{$fallback});
+                        }
+                    }
+
+                    --ig-theme: material;
+                    --ig-theme-variant: light;
+                }
+            }
+        }
+
+        @include it('should not prepend a prefix when the theme map has no prefix property') {
+            $theme: digest-schema($schema);
+            $name: map.get($theme, '_meta', 'name');
+            $vp: config.variable-prefix();
+
+            // Verify no prefix key exists in the digested schema
+            @include assert-false(map.get($theme, 'prefix'), 'Digested schema should not have a prefix key');
+
+            @include assert() {
+                @include output() {
+                    @include css-vars-from-theme($theme);
+                }
+
+                @include expect() {
+                    @each $key, $value in map.remove($theme, $ignored-keys...) {
+                        $fallback: if($vp == 'ig', #{$value}, var(--ig-#{$name}-#{$key}, #{$value}));
+
+                        --#{$key}: var(--#{$vp}-#{$name}-#{$key}, #{$fallback});
+                    }
+
+                    --ig-theme: material;
+                    --ig-theme-variant: light;
+                }
+            }
+        }
+
+        @include it('should scope prefixed CSS variables correctly via the tokens mixin') {
+            $selector: 'igc-dockmanager';
+            $theme: map.merge(
+                digest-schema($schema),
+                (
+                    selector: $selector,
+                    prefix: 'igc',
+                )
+            );
+            $name: map.get($theme, '_meta', 'name');
+            $vp: config.variable-prefix();
+
+            @include assert() {
+                @include output($selector: false) {
+                    @include tokens($theme, $mode: 'scoped');
+                }
+
+                @include expect($selector: false) {
+                    #{$selector} {
+                        @each $key, $value in map.remove($theme, $ignored-keys...) {
+                            @if $key != 'prefix' {
+                                $fallback: if($vp == 'ig', #{$value}, var(--ig-#{$name}-#{$key}, #{$value}));
+
+                                --igc-#{$key}: var(--#{$vp}-#{$name}-#{$key}, #{$fallback});
+                            }
+                        }
+
+                        --ig-theme: material;
+                        --ig-theme-variant: light;
+                    }
+                }
+            }
+        }
+
         @include it('should ignore $name property when provided to css-vars-from-theme mixin') {
             $theme: digest-schema($schema);
             $name: map.get($theme, '_meta', 'name');


### PR DESCRIPTION
Closes #549

The `css-vars-from-theme` mixin ignored the `prefix` property set in component theme maps (e.g. `prefix: 'igc'` in `dock-manager-theme`), causing local CSS variables to be emitted without the required prefix.

Introduce a `$local` variable that prepends the prefix only to the local variable name while keeping the global fallback chain unprefixed:

```scss
--igc-active-color: var(--igx-dockmanager-active-color, ...);
```

Previously, the mixin emitted:

```scss
--active-color: var(--igx-dockmanager-active-color, ...);
```