### PR TITLE
fix(bem): resolve adjacent-compounds deprecation warnings

### DIFF
--- a/packages/theming/sass/bem/_index.scss
+++ b/packages/theming/sass/bem/_index.scss
@@ -150,6 +150,14 @@ $_bem-mod-cache: () !default;
     @return string.index($x, ':');
 }
 
+/// Checks if the passed selector string contains an attribute selector.
+/// @access private
+/// @param {String} $x - The string to check for attribute selectors.
+/// @returns {number|null} Will return the index of the occurrence, or null if the string does not contain any attribute selectors.
+@function bem--contains-attr($x) {
+    @return string.index($x, '[');
+}
+
 /// Returns the BEM block-name that generated `$x`. Does not include leading ".".
 /// @access private
 /// @param {String} $x - The block name.
@@ -160,6 +168,16 @@ $_bem-mod-cache: () !default;
         @return string.slice($x, 1, string.index($x, $bem--sep-elem) - 1);
     } @else if bem--contains-pseudo($x) {
         @return string.slice($x, 1, string.index($x, ':') - 1);
+    } @else if bem--contains-attr($x) {
+        $attr-idx: string.index($x, '[');
+        $end: $attr-idx - 1;
+
+        // Trim trailing descendant-combinator space before [
+        @if string.slice($x, $end, $end) == ' ' {
+            $end: $end - 1;
+        }
+
+        @return string.slice($x, 1, $end);
     }
 
     @return $x;
@@ -169,7 +187,13 @@ $_bem-mod-cache: () !default;
 /// @access private
 @function bem--extract-first-selector($x) {
     $parens: string.index($x, '(');
-    $eow: if($parens, string.index($x, ')'), string.index($x, ' ') or -1);
+    $space: string.index($x, ' ');
+    $bracket: string.index($x, '[');
+
+    // A space that precedes an attribute selector is a descendant combinator —
+    // treat the whole selector as a single unit (no split before the [...])
+    $space-before-attr: $space and $bracket and $space < $bracket;
+    $eow: if($parens, string.index($x, ')'), if($space-before-attr, -1, $space or -1));
 
     @return string.slice($x, 1, $eow);
 }
@@ -403,7 +427,7 @@ $_bem-mod-cache: () !default;
     $context: bem--selector-to-string(&);
     $block: bem--extract-block($context);
     $first: bem--extract-first-selector($context);
-    $nested: bem--contains-pseudo($context) or bem--contains-mod($context);
+    $nested: bem--contains-pseudo($context) or bem--contains-mod($context) or bem--contains-attr($context);
     $mod: $m or $mod;
 
     // Validate context

--- a/packages/theming/tests/_bem.spec.scss
+++ b/packages/theming/tests/_bem.spec.scss
@@ -294,6 +294,96 @@
         }
     }
 
+    @include it('creates element selector inside an attribute selector context') {
+        @include assert() {
+            @include output($selector: false) {
+                @include b(block) {
+                    &[aria-selected=false] {
+                        @include e(element) {
+                            display: none;
+                        }
+                    }
+                }
+            }
+
+            @include expect($selector: false) {
+                .block[aria-selected=false] .block__element {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    @include it('creates element--modifier selector inside an attribute selector context') {
+        @include assert() {
+            @include output($selector: false) {
+                @include b(block) {
+                    &[aria-selected=false] {
+                        @include e(element, $m: active) {
+                            display: block;
+                        }
+                    }
+                }
+            }
+
+            @include expect($selector: false) {
+                .block[aria-selected=false] .block__element--active {
+                    display: block;
+                }
+            }
+        }
+    }
+
+    @include it('creates multiple element modifier selectors inside an attribute selector context') {
+        @include assert() {
+            @include output($selector: false) {
+                @include b(block) {
+                    &[aria-selected=false] {
+                        @include e(element, $mods: (small, pink)) {
+                            font-size: 12px;
+                        }
+                    }
+                }
+            }
+
+            @include expect($selector: false) {
+                .block[aria-selected=false] .block__element--small.block__element--pink {
+                    font-size: 12px;
+                }
+            }
+        }
+    }
+
+    @include it('creates element selector inside a descendant attribute selector context') {
+        @include assert() {
+            @include output($selector: false) {
+                @include b(block) {
+                    [aria-selected=true] {
+                        @include e(element) {
+                            display: block;
+                        }
+                    }
+
+                    [aria-selected=false] {
+                        @include e(element) {
+                            display: none;
+                        }
+                    }
+                }
+            }
+
+            @include expect($selector: false) {
+                .block [aria-selected=true] .block__element {
+                    display: block;
+                }
+
+                .block [aria-selected=false] .block__element {
+                    display: none;
+                }
+            }
+        }
+    }
+
     @include it('should be able to use element classes in modifier body rules') {
         @include assert() {
             @include output($selector: false) {


### PR DESCRIPTION
 Closes #581

The bem-elem mixin was generating invalid adjacent compound selectors (e.g. [aria-selected=false]__content-wrapper) when called inside an attribute selector block.

Root cause: bem--extract-block and the $nested flag had no awareness of [...] attribute selectors — both treated them as plain block context, causing the element separator __ to be appended directly onto the attribute selector.

Changes:
 - Add `bem--contains-attr()` — detects `[` in a selector string
 - Update `bem--extract-block` — strips `[...]` (and any preceding descendant-combinator space) to return the bare block name
 - Update `bem--extract-first-selector` — treats a space before `[` as a descendant combinator, keeping the full selector intact as `$first`
 - Update `$nested` in `bem-elem` — attribute selector contexts are now correctly treated as nested, producing `block[attr] block__elem` (compound) and `block [attr] block__elem` (descendant)
 - Add 4 spec cases covering both forms and their modifier variants

The easiest way to test the fixes in this PR is to install the package in the scoped-styles branch in Ignite UI for Angular.