### PR TITLE
feat(qr-code): add qr-code component theme

### DIFF
--- a/packages/theming/sass/themes/components/_index.scss
+++ b/packages/theming/sass/themes/components/_index.scss
@@ -33,6 +33,7 @@
 @forward 'paginator/paginator-theme';
 @forward 'progress/circular-theme';
 @forward 'progress/linear-theme';
+@forward 'qr-code/qr-code-theme';
 @forward 'query-builder/query-builder-theme';
 @forward 'radio/radio-theme';
 @forward 'rating/rating-theme';

--- a/packages/theming/sass/themes/components/qr-code/_qr-code-theme.scss
+++ b/packages/theming/sass/themes/components/qr-code/_qr-code-theme.scss
@@ -1,0 +1,69 @@
+@use 'sass:map';
+@use '../../config';
+@use '../../functions' as *;
+@use '../../schemas/' as *;
+@use '../../../utils/map' as *;
+
+////
+/// @package theming
+/// @group themes
+/// @access public
+////
+
+/// QR Code Theme
+///
+/// PRIMARY TOKENS:
+/// - `$background` — The QR code background color.
+/// - `$dark-color` — The color of the dark (data) modules.
+///
+/// `$corner-square-color` and `$corner-dot-color` fall back to `$dark-color` when not set,
+/// so a two-tone QR code only requires setting `$background` and `$dark-color`.
+///
+/// @param {Map} $schema [$light-material-schema] - The schema used as basis for styling the component.
+/// @param {Color} $background [null] - The background color of the QR code. PRIMARY.
+/// @param {Color} $dark-color [null] - The color used for the dark (data) modules of the QR code. PRIMARY - falls back for corner-square-color, corner-dot-color.
+/// @param {Color} $corner-square-color [null] - The fill color for the outer corner (finder-pattern) squares. Falls back to dark-color.
+/// @param {Color} $corner-dot-color [null] - The fill color for the inner corner (finder-pattern) dots. Falls back to dark-color.
+/// @requires $light-material-schema
+///
+/// @example scss - Change the data module and background colors
+///   $my-qr-code-theme: qr-code-theme($background: white, $dark-color: black);
+///   // Pass the theme to the css-vars() mixin
+///   @include css-vars($my-qr-code-theme);
+@function qr-code-theme(
+    $schema: $light-material-schema,
+    $background: null,
+    $dark-color: null,
+    $corner-square-color: null,
+    $corner-dot-color: null
+) {
+    $selector: #{config.element-prefix() + '-' + 'qr-code'};
+    $qr-code-schema: ();
+
+    @if map.has-key($schema, 'qr-code') {
+        $qr-code-schema: map.get($schema, 'qr-code');
+    } @else {
+        $qr-code-schema: $schema;
+    }
+
+    $theme: digest-schema($qr-code-schema);
+
+    @if not($corner-square-color) and $dark-color {
+        $corner-square-color: $dark-color;
+    }
+
+    @if not($corner-dot-color) and $dark-color {
+        $corner-dot-color: $dark-color;
+    }
+
+    @return extend(
+        $theme,
+        (
+            selector: $selector,
+            background: $background,
+            dark-color: $dark-color,
+            corner-square-color: $corner-square-color,
+            corner-dot-color: $corner-dot-color,
+        )
+    );
+}

--- a/packages/theming/sass/themes/components/qr-code/_qr-code-theme.scss
+++ b/packages/theming/sass/themes/components/qr-code/_qr-code-theme.scss
@@ -16,8 +16,9 @@
 /// - `$background` — The QR code background color.
 /// - `$dark-color` — The color of the dark (data) modules.
 ///
-/// `$corner-square-color` and `$corner-dot-color` fall back to `$dark-color` when not set,
-/// so a two-tone QR code only requires setting `$background` and `$dark-color`.
+/// `$corner-square-color` and `$corner-dot-color` default to a live `var(--dark-color)`
+/// reference in the schema, so they automatically track `$dark-color` - including plain CSS
+/// custom property overrides at runtime - unless a caller sets a corner color explicitly.
 ///
 /// @param {Map} $schema [$light-material-schema] - The schema used as basis for styling the component.
 /// @param {Color} $background [null] - The background color of the QR code. PRIMARY.
@@ -47,14 +48,6 @@
     }
 
     $theme: digest-schema($qr-code-schema);
-
-    @if not($corner-square-color) and $dark-color {
-        $corner-square-color: $dark-color;
-    }
-
-    @if not($corner-dot-color) and $dark-color {
-        $corner-dot-color: $dark-color;
-    }
 
     @return extend(
         $theme,

--- a/packages/theming/sass/themes/schemas/components/dark/_index.scss
+++ b/packages/theming/sass/themes/schemas/components/dark/_index.scss
@@ -43,6 +43,7 @@
 @use './pagination' as *;
 @use './pivot-data-selector' as *;
 @use './progress' as *;
+@use './qr-code' as *;
 @use './query-builder' as *;
 @use './radio' as *;
 @use './rating' as *;
@@ -109,6 +110,7 @@ $dark-material-schema: (
     pivot-data-selector: $dark-material-pivot-data-selector,
     linear-bar: $dark-material-progress-linear,
     circular-bar: $dark-material-progress-circular,
+    qr-code: $dark-material-qr-code,
     query-builder: $dark-material-query-builder,
     radio: $dark-material-radio,
     rating: $dark-material-rating,
@@ -180,6 +182,7 @@ $dark-fluent-schema: (
     pivot-data-selector: $dark-fluent-pivot-data-selector,
     linear-bar: $dark-fluent-progress-linear,
     circular-bar: $dark-fluent-progress-circular,
+    qr-code: $dark-fluent-qr-code,
     query-builder: $dark-fluent-query-builder,
     radio: $dark-fluent-radio,
     rating: $dark-fluent-rating,
@@ -251,6 +254,7 @@ $dark-bootstrap-schema: (
     pivot-data-selector: $dark-bootstrap-pivot-data-selector,
     linear-bar: $dark-bootstrap-progress-linear,
     circular-bar: $dark-bootstrap-progress-circular,
+    qr-code: $dark-bootstrap-qr-code,
     query-builder: $dark-bootstrap-query-builder,
     radio: $dark-bootstrap-radio,
     rating: $dark-bootstrap-rating,
@@ -322,6 +326,7 @@ $dark-indigo-schema: (
     pivot-data-selector: $dark-indigo-pivot-data-selector,
     linear-bar: $dark-indigo-progress-linear,
     circular-bar: $dark-indigo-progress-circular,
+    qr-code: $dark-indigo-qr-code,
     query-builder: $dark-indigo-query-builder,
     radio: $dark-indigo-radio,
     rating: $dark-indigo-rating,

--- a/packages/theming/sass/themes/schemas/components/dark/_qr-code.scss
+++ b/packages/theming/sass/themes/schemas/components/dark/_qr-code.scss
@@ -1,0 +1,45 @@
+@use '../../../../utils/map' as *;
+@use '../light/qr-code' as *;
+
+////
+/// @package theming
+/// @group schemas
+/// @access public
+////
+
+/// Generates a base dark qr-code schema.
+/// @access private
+/// @type Map
+/// No value overrides - background/dark-color are fixed literal colors (white/black) in the
+/// light schema, deliberately not derived from the surface-relative `gray` scale, so they do
+/// not invert when the app switches to a dark palette. See ../light/_qr-code.scss for details.
+$dark-base-qr-code: (
+    _meta: (
+        name: 'qr-code',
+        variant: 'dark',
+    ),
+);
+
+/// Generates a dark material qr-code schema.
+/// @type Map
+/// @requires $material-qr-code
+/// @requires $dark-base-qr-code
+$dark-material-qr-code: extend($material-qr-code, $dark-base-qr-code);
+
+/// Generates a dark fluent qr-code schema.
+/// @type Map
+/// @requires $fluent-qr-code
+/// @requires $dark-base-qr-code
+$dark-fluent-qr-code: extend($fluent-qr-code, $dark-base-qr-code);
+
+/// Generates a dark bootstrap qr-code schema.
+/// @type Map
+/// @requires $bootstrap-qr-code
+/// @requires $dark-base-qr-code
+$dark-bootstrap-qr-code: extend($bootstrap-qr-code, $dark-base-qr-code);
+
+/// Generates a dark indigo qr-code schema.
+/// @type Map
+/// @requires $indigo-qr-code
+/// @requires $dark-base-qr-code
+$dark-indigo-qr-code: extend($indigo-qr-code, $dark-base-qr-code);

--- a/packages/theming/sass/themes/schemas/components/light/_index.scss
+++ b/packages/theming/sass/themes/schemas/components/light/_index.scss
@@ -43,6 +43,7 @@
 @use './pagination' as *;
 @use './pivot-data-selector' as *;
 @use './progress' as *;
+@use './qr-code' as *;
 @use './query-builder' as *;
 @use './radio' as *;
 @use './rating' as *;
@@ -109,6 +110,7 @@ $light-material-schema: (
     pivot-data-selector: $material-pivot-data-selector,
     linear-bar: $material-progress-linear,
     circular-bar: $material-progress-circular,
+    qr-code: $material-qr-code,
     query-builder: $material-query-builder,
     radio: $material-radio,
     rating: $material-rating,
@@ -180,6 +182,7 @@ $light-fluent-schema: (
     pivot-data-selector: $fluent-pivot-data-selector,
     linear-bar: $fluent-progress-linear,
     circular-bar: $fluent-progress-circular,
+    qr-code: $fluent-qr-code,
     query-builder: $fluent-query-builder,
     radio: $fluent-radio,
     rating: $fluent-rating,
@@ -251,6 +254,7 @@ $light-bootstrap-schema: (
     pivot-data-selector: $bootstrap-pivot-data-selector,
     linear-bar: $bootstrap-progress-linear,
     circular-bar: $bootstrap-progress-circular,
+    qr-code: $bootstrap-qr-code,
     query-builder: $bootstrap-query-builder,
     radio: $bootstrap-radio,
     rating: $bootstrap-rating,
@@ -322,6 +326,7 @@ $light-indigo-schema: (
     pivot-data-selector: $indigo-pivot-data-selector,
     linear-bar: $indigo-progress-linear,
     circular-bar: $indigo-progress-circular,
+    qr-code: $indigo-qr-code,
     query-builder: $indigo-query-builder,
     radio: $indigo-radio,
     rating: $indigo-rating,

--- a/packages/theming/sass/themes/schemas/components/light/_qr-code.scss
+++ b/packages/theming/sass/themes/schemas/components/light/_qr-code.scss
@@ -1,0 +1,83 @@
+@use '../../../../utils/map' as *;
+
+////
+/// @package theming
+/// @group schemas
+/// @access public
+////
+
+/// Generates a light qr-code schema.
+///
+/// `background`/`dark-color` are fixed literal colors (not palette-relative `gray` shades) so
+/// the QR code stays reliably dark-on-light regardless of whether the consuming app is using
+/// a light or dark palette - the `gray` scale is derived from the active `$surface` luminance
+/// and inverts in dark mode, which would silently flip the code to light-on-dark and risk
+/// scan failures on many real-world QR scanners. `corner-square-color` and `corner-dot-color`
+/// are set to a live `var(--dark-color)` reference rather than a literal, so they automatically
+/// track `dark-color` - including plain CSS custom property overrides at runtime - unless a
+/// consumer sets a corner color explicitly. The `qr-code-theme()` function additionally derives
+/// a literal value for them when `$dark-color` is passed as an explicit Sass argument.
+///
+/// @type Map
+/// @prop {Color} background [white] - The background color of the QR code.
+/// @prop {Color} dark-color [black] - The color used for the dark (data) modules of the QR code.
+/// @prop {String} corner-square-color [var(--dark-color)] - The fill color for the outer corner squares of the QR code. Tracks dark-color by default.
+/// @prop {String} corner-dot-color [var(--dark-color)] - The fill color for the inner corner dots of the QR code. Tracks dark-color by default.
+$light-qr-code: (
+    background: white,
+    dark-color: black,
+    corner-square-color: var(--dark-color),
+    corner-dot-color: var(--dark-color),
+    _meta: (
+        name: 'qr-code',
+        variant: 'light',
+    ),
+);
+
+/// Generates a material qr-code schema.
+/// @type Map
+/// @requires $light-qr-code
+$material-qr-code: extend(
+    $light-qr-code,
+    (
+        _meta: (
+            theme: 'material',
+        ),
+    )
+);
+
+/// Generates a fluent qr-code schema.
+/// @type Map
+/// @requires $light-qr-code
+$fluent-qr-code: extend(
+    $light-qr-code,
+    (
+        _meta: (
+            theme: 'fluent',
+        ),
+    )
+);
+
+/// Generates a bootstrap qr-code schema.
+/// @type Map
+/// @requires $light-qr-code
+$bootstrap-qr-code: extend(
+    $light-qr-code,
+    (
+        _meta: (
+            theme: 'bootstrap',
+        ),
+    )
+);
+
+/// Generates an indigo qr-code schema.
+/// @type Map
+/// @requires $light-qr-code
+$indigo-qr-code: extend(
+    $light-qr-code,
+    (
+        _meta: (
+            theme: 'indigo',
+        ),
+    )
+);


### PR DESCRIPTION
Registers `qr-code` as a themed component with schema, theme function, and index wiring, exposing background, dark-color, corner-square-color, and corner-dot-color tokens for igc-qr-code.